### PR TITLE
WIP for #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 ## jte Spring Boot demo
 
 A simple demo of jte running with Spring Boot.
+
+---
+
+### Deploy to Heroku
+
+Requirements: Heroku CLI
+
+- git clone
+- cd into project
+- heroku apps:create jte-demo --region eu
+  - echo "This creates a 'heroku' remote repo"
+  - git remote -v show
+- git push heroku
+- https://jte-demo.herokuapp.com/
+- heroku apps:destroy jte-demo
+

--- a/src/main/java/gg/jte/demo/DemoController.java
+++ b/src/main/java/gg/jte/demo/DemoController.java
@@ -1,8 +1,10 @@
 package gg.jte.demo;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -13,6 +15,15 @@ public class DemoController {
     TemplateRenderer templateRenderer;
     @Autowired
     VisitsRepository visitsRepository;
+
+    @Value("${spring.profiles.active:PROFILE_NOT_SET}")
+    private String profile;
+
+    @ResponseBody
+    @GetMapping(value = "/profile")
+    public String profile() {
+        return profile;
+    }
 
     @GetMapping("/")
     public void view(HttpServletResponse response) {

--- a/src/main/java/gg/jte/demo/TemplateRenderer.java
+++ b/src/main/java/gg/jte/demo/TemplateRenderer.java
@@ -23,7 +23,7 @@ public class TemplateRenderer {
     private final TemplateEngine templateEngine;
 
     public TemplateRenderer() {
-        if (profile != "prod") {
+        if ("prod".equals(profile)) {
             CodeResolver codeResolver = new DirectoryCodeResolver(Path.of("src", "main", "jte"));
             templateEngine = TemplateEngine.create(codeResolver, Paths.get("jte-classes"), ContentType.Html, getClass().getClassLoader());
             templateEngine.setBinaryStaticContent(true);

--- a/src/main/java/gg/jte/demo/TemplateRenderer.java
+++ b/src/main/java/gg/jte/demo/TemplateRenderer.java
@@ -5,6 +5,7 @@ import gg.jte.ContentType;
 import gg.jte.TemplateEngine;
 import gg.jte.output.Utf8ByteOutput;
 import gg.jte.resolve.DirectoryCodeResolver;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletResponse;
@@ -16,13 +17,13 @@ import java.nio.file.Paths;
 @Service
 public class TemplateRenderer {
 
-    // TODO determine if we run spring boot in development mode or not
-    private final boolean devMode = false;
+    @Value("${spring.profiles.active}")
+    private String profile;
 
     private final TemplateEngine templateEngine;
 
     public TemplateRenderer() {
-        if (devMode) {
+        if (profile != "prod") {
             CodeResolver codeResolver = new DirectoryCodeResolver(Path.of("src", "main", "jte"));
             templateEngine = TemplateEngine.create(codeResolver, Paths.get("jte-classes"), ContentType.Html, getClass().getClassLoader());
             templateEngine.setBinaryStaticContent(true);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
-
-# Ctrl-F9 will trigger a browser refresh, which will then force JTE to recompile the edited template
+# Ctrl-F9 will trigger a browser refresh, which will then force JTE to recompile the edited template
 spring.devtools.restart.additional-paths=./src/main/jte
+
+# This env var is optional in dev, required in prod
+# SPRING_ENV=dev ./mvnw spring-boot:run
+spring.profiles.active=${SPRING_ENV:NOT_SET}

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,2 @@
+# Heroku/Dokku require this file
+java.runtime.version=11


### PR DESCRIPTION
Hello @casid 

I think I've got an okayish config here. I'm not sure if it's idiomatic but should be simple enough to demonstrate a quick deployment strategy.

I thought I was mostly done because the deployment **did** work for a while.

However it broke again after tweaking only the controller+view code.

---

heroku logs -t

```
2021-05-31T18:51:09.725821+00:00 app[web.1]: /app/jte-classes/gg/jte/generated/ondemand/JtedemoGenerated.java:2: error: package gg.jte.demo does not exist                                                                                    
2021-05-31T18:51:09.725821+00:00 app[web.1]: import gg.jte.demo.DemoModel; 
```

So I think I'm still hitting that class loader problem, and I got lucky with a running config temporarily.