### PR TITLE
enforce utf-8 encoding when rendering templates

### DIFF
--- a/src/main/java/gg/jte/demo/DemoController.java
+++ b/src/main/java/gg/jte/demo/DemoController.java
@@ -30,7 +30,7 @@ public class DemoController {
         visitsRepository.add();
 
         DemoModel model = new DemoModel();
-        model.name = "unknown visitor";
+        model.name = "mystérieux visiteur";
         model.visits = visitsRepository.get();
 
         templateRenderer.render("demo.jte", model, response);

--- a/src/main/java/gg/jte/demo/TemplateRenderer.java
+++ b/src/main/java/gg/jte/demo/TemplateRenderer.java
@@ -5,11 +5,13 @@ import gg.jte.ContentType;
 import gg.jte.TemplateEngine;
 import gg.jte.output.Utf8ByteOutput;
 import gg.jte.resolve.DirectoryCodeResolver;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -36,7 +38,8 @@ public class TemplateRenderer {
         Utf8ByteOutput output = new Utf8ByteOutput();
         templateEngine.render(name, model, output);
 
-        response.setContentType("text/html");
+        response.setContentType(MediaType.TEXT_HTML_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentLength(output.getContentLength());
 
         try {


### PR DESCRIPTION
Without enforcing the encoding umlauts and other non ascii characters are not correctly encoded. While it is mentioned in the official documentation correctly I guess most people will look at the example and copy the renderer.

Without correct encoding:

![image](https://user-images.githubusercontent.com/203401/160137427-923489d1-f290-498e-a9bb-0a074f25d78e.png)

With UTF-8 encoding:

![image](https://user-images.githubusercontent.com/203401/160137840-f458eb63-05cd-401c-9fe8-3338c3226066.png)

